### PR TITLE
fix(autocmds): do not render when mode changed

### DIFF
--- a/lua/sentiment/autocmds.lua
+++ b/lua/sentiment/autocmds.lua
@@ -17,7 +17,6 @@ local renderer = Autocmd.new({
   events = {
     "BufWinEnter",
     "WinScrolled",
-    "ModeChanged",
     "CursorMoved",
     "CursorMovedI",
   },


### PR DESCRIPTION
May related to https://github.com/utilyre/sentiment.nvim/issues/12.

I found it was added in d43f3db1, but this should not be needed for this feature.